### PR TITLE
EquipmentMaintenanceViewSet create() method added

### DIFF
--- a/labfairyapi/models/equipmentmaintenance.py
+++ b/labfairyapi/models/equipmentmaintenance.py
@@ -1,5 +1,8 @@
 from django.db import models
 from django.contrib.auth.models import User
+from django.core.validators import MinValueValidator
+from django.utils import timezone
+import datetime
 
 
 class EquipmentMaintenance(models.Model):
@@ -10,10 +13,20 @@ class EquipmentMaintenance(models.Model):
         "Maintenance", on_delete=models.CASCADE, related_name="tickets"
     )
     date_request_completed = models.DateTimeField(auto_now_add=True)
-    date_needed = models.DateField()
-    date_scheduled = models.DateField(null=True)
-    date_completed = models.DateTimeField(null=True)
-    notes = models.TextField(null=True)
+    date_needed = models.DateField(
+        validators=[
+            MinValueValidator(timezone.now().date() + datetime.timedelta(days=1))
+        ]
+    )
+    date_scheduled = models.DateField(
+        null=True,
+        blank=True,
+        validators=[
+            MinValueValidator(timezone.now().date() + datetime.timedelta(days=1))
+        ],
+    )
+    date_completed = models.DateTimeField(null=True, blank=True)
+    notes = models.TextField(null=True, blank=True)
     user = models.ForeignKey(User, on_delete=models.SET_DEFAULT, default=1)
 
     def __str__(self):

--- a/labfairyapi/serializers/__init__.py
+++ b/labfairyapi/serializers/__init__.py
@@ -4,3 +4,4 @@ from .equipment import (
     EquipmentFullSerializer,
 )
 from .labequipment import LabEquipmentSerializer
+from .equipmentmaintenance import EquipmentMaintenanceSerializer

--- a/labfairyapi/serializers/equipmentmaintenance.py
+++ b/labfairyapi/serializers/equipmentmaintenance.py
@@ -1,0 +1,23 @@
+from rest_framework import serializers
+from labfairyapi.models import Equipment, Maintenance, EquipmentMaintenance
+
+
+class EquipmentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Equipment
+        fields = ("id", "name")
+
+
+class MaintenanceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Maintenance
+        fields = ("id", "name", "days_interval")
+
+
+class EquipmentMaintenanceSerializer(serializers.ModelSerializer):
+    equipment = EquipmentSerializer(many=False)
+    maintenance = MaintenanceSerializer(many=False)
+
+    class Meta:
+        model = EquipmentMaintenance
+        fields = ("id", "equipment", "maintenance", "date_needed", "date_scheduled")

--- a/labfairyapi/views/__init__.py
+++ b/labfairyapi/views/__init__.py
@@ -1,2 +1,3 @@
 from .equipment import EquipmentViewSet
 from .labequipment import LabEquipmentViewSet
+from .equipmentmaintenance import EquipmentMaintenanceViewSet

--- a/labfairyapi/views/equipmentmaintenance.py
+++ b/labfairyapi/views/equipmentmaintenance.py
@@ -1,0 +1,60 @@
+from django.shortcuts import get_object_or_404
+from django.core.exceptions import ValidationError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import status
+from labfairyapi.models import Equipment, Maintenance, EquipmentMaintenance
+from labfairyapi.serializers import EquipmentMaintenanceSerializer
+
+
+class EquipmentMaintenanceViewSet(ViewSet):
+    def create(self, request):
+        current_user = request.auth.user
+
+        # Check for required keys in the request body
+        equipment_id = request.data.get("equipment_id")
+        maintenance_id = request.data.get("maintenance_id")
+        date_needed = request.data.get("date_needed")
+
+        if not equipment_id or not maintenance_id or not date_needed:
+            return Response(
+                {
+                    "error": "Missing required fields: equipment_id, maintenance_id, and/or date_needed"
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        equipment = get_object_or_404(Equipment, pk=equipment_id)
+        maintenance_type = get_object_or_404(Maintenance, pk=maintenance_id)
+
+        # Create a new EquipmentMaintenance in memory (i.e. as opposed to create) with the required keys
+        new_maintenance_ticket = EquipmentMaintenance(
+            equipment=equipment,
+            maintenance=maintenance_type,
+            date_needed=date_needed,
+            user=current_user,
+        )
+
+        # Check for optional keys in the request body
+        date_scheduled = request.data.get("date_scheduled")
+        notes = request.data.get("notes")
+
+        if date_scheduled is not None:
+            # Only allow superuser to complete scheduling
+            if current_user.is_superuser:
+                new_maintenance_ticket.date_scheduled = date_scheduled
+
+        if notes is not None:
+            new_maintenance_ticket.notes = notes
+
+        # Run through model validators before saving the in-memory instance to the database
+        try:
+            new_maintenance_ticket.full_clean()
+            new_maintenance_ticket.save()
+        except ValidationError as e:
+            return Response({"error": e.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Serialize the EquipmentMaintenance
+        serializer = EquipmentMaintenanceSerializer(new_maintenance_ticket, many=False)
+
+        return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/labfairyproject/urls.py
+++ b/labfairyproject/urls.py
@@ -7,5 +7,6 @@ from labfairyapi.views import *
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r"equipment", EquipmentViewSet, "equipment")
 router.register(r"labequipment", LabEquipmentViewSet, "labequipment")
+router.register(r"maintenance", EquipmentMaintenanceViewSet, "equipmentmaintenance")
 
 urlpatterns = [path("", include(router.urls)), path("admin/", admin.site.urls)]


### PR DESCRIPTION
## Changes
* created EquipmentMaintenanceSerializer and nested EquipmentSerializer and MaintenanceSerializer. Imported into /serializers init
* created EquipmentMaintenanceViewSet and imported into /views init
* wrote create() method in LabEquipmentViewSet
* registered EquipmentMaintenanceViewSet to /maintenance in urls.py
* added MinValueValidators to date_needed and date_scheduled to restrict these fields to dates at least 1 day in the future
* added blank=Null parameters to fields that accept null values so they do not raise errors when running the instance through validators with full_clean()